### PR TITLE
Fix/submitted tests terminology

### DIFF
--- a/locales/en-US/messages.po
+++ b/locales/en-US/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: TAO 3.1.0-sprint20\n"
-"PO-Revision-Date: 2016-02-26T10:04:11\n"
+"Project-Id-Version: TAO 3.2.0-sprint42\n"
+"PO-Revision-Date: 2017-01-09T14:41:49\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-US\n"
@@ -13,14 +13,68 @@ msgstr ""
 "X-Poedit-KeywordsList: __\n"
 "X-Poedit-SearchPath-0: .\n"
 
-msgid "Hello World"
+msgid "Active users"
+msgstr ""
+
+msgid "Closed"
+msgstr ""
+
+msgid "Connected Users"
+msgstr ""
+
+msgid "Current status"
 msgstr ""
 
 #, tao-public
-msgid "tao-extension-monitoring"
+msgid "Delivery Executions"
 msgstr ""
 
 #, tao-public
-msgid "Template"
+msgid "Delivery Executions Monitoring"
+msgstr ""
+
+#, tao-public
+msgid "Delivery Executions Monitoring library"
+msgstr ""
+
+msgid "Executions"
+msgstr ""
+
+msgid "Hours"
+msgstr ""
+
+#, tao-public
+msgid "Monitoring"
+msgstr ""
+
+msgid "No tests have been taken yet. As soon as a test-taker will take a test his results will be displayed here."
+msgstr ""
+
+msgid "Open"
+msgstr ""
+
+msgid "Start Time"
+msgstr ""
+
+msgid "Started tests"
+msgstr ""
+
+msgid "Test Taker"
+msgstr ""
+
+msgid "Time Frame"
+msgstr ""
+
+msgid "Total Expected"
+msgstr ""
+
+msgid "Unlimited"
+msgstr ""
+
+msgid "Users activity"
+msgstr ""
+
+#, tao-public
+msgid "View and format the collected monitoring data."
 msgstr ""
 

--- a/locales/en-US/messages.po
+++ b/locales/en-US/messages.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TAO 3.2.0-sprint42\n"
-"PO-Revision-Date: 2017-01-09T14:41:49\n"
+"PO-Revision-Date: 2017-01-10T08:37:16\n"
 "Last-Translator: TAO Translation Team <translation@tao.lu>\n"
 "MIME-Version: 1.0\n"
 "Language: en-US\n"
@@ -56,7 +56,7 @@ msgstr ""
 msgid "Start Time"
 msgstr ""
 
-msgid "Started tests"
+msgid "Started Delivery Executions"
 msgstr ""
 
 msgid "Test Taker"

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
 	'label' => 'Statistics and aggregated data',
 	'description' => 'Extension for monitoring of the tao events. Fast access to statistics data',
     'license' => 'GPL-2.0',
-    'version' => '0.3.0',
+    'version' => '0.3.1',
 	'author' => 'Open Assessment Technologies SA',
 	'requires' => array(
         'generis' => '>=2.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -90,6 +90,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '0.3.0');
+        $this->skip('0.1.0', '0.3.1');
     }
 }

--- a/views/templates/DeliveryExecutions/index.tpl
+++ b/views/templates/DeliveryExecutions/index.tpl
@@ -27,7 +27,7 @@ use oat\tao\helpers\Template;
     
     <div class="data-container-wrapper flex-container-remainer">
         <header>
-            <h3><?= __('Submitted tests') ?></h3>
+            <h3><?= __('Started tests') ?></h3>
         </header>
         
         <div class="delivery-executions-progress">

--- a/views/templates/DeliveryExecutions/index.tpl
+++ b/views/templates/DeliveryExecutions/index.tpl
@@ -27,7 +27,7 @@ use oat\tao\helpers\Template;
     
     <div class="data-container-wrapper flex-container-remainer">
         <header>
-            <h3><?= __('Started tests') ?></h3>
+            <h3><?= __('Started Delivery Executions') ?></h3>
         </header>
         
         <div class="delivery-executions-progress">


### PR DESCRIPTION
As far as when a test is **started**, it appears as a "submitted test" in the monitoring screen, I would suggest to change the "Submitted Tests" terminology into "Started Tests" to reflect the reality to the end user.