### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'Statistics and aggregated data',
     'description' => 'Extension for monitoring of the tao events. Fast access to statistics data',
     'license' => 'GPL-2.0',
-    'version' => '2.3.0',
+    'version' => '3.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'Statistics and aggregated data',
     'description' => 'Extension for monitoring of the tao events. Fast access to statistics data',
     'license' => 'GPL-2.0',
-    'version' => '2.2.3',
+    'version' => '2.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=2.15.0',

--- a/manifest.php
+++ b/manifest.php
@@ -27,7 +27,7 @@ return array(
     'version' => '2.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
-        'generis'        => '>=2.15.0',
+        'generis'        => '>=12.5.0',
         'tao'            => '>=21.0.0',
         'taoDelivery'    => '>=11.0.0',
         'taoDeliveryRdf' => '>=6.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -148,6 +148,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('2.2.2');
         }
         
-        $this->skip('2.2.2', '2.2.3');
+        $this->skip('2.2.2', '2.3.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -148,6 +148,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('2.2.2');
         }
         
-        $this->skip('2.2.2', '2.3.0');
+        $this->skip('2.2.2', '3.0.0');
     }
 }

--- a/test/MonitoringPlugServiceTest.php
+++ b/test/MonitoringPlugServiceTest.php
@@ -22,8 +22,9 @@ namespace oat\taoMonitoring\test;
 
 
 use oat\taoMonitoring\model\MonitoringPlugService;
+use oat\generis\test\TestCase;
 
-class MonitoringPlugServiceTest extends \PHPUnit_Framework_TestCase
+class MonitoringPlugServiceTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.