### PR TITLE
Tdr 22 remove deprecated method usage

### DIFF
--- a/controller/DeliveryExecutions.php
+++ b/controller/DeliveryExecutions.php
@@ -122,8 +122,6 @@ class DeliveryExecutions extends tao_actions_SaSModule
         //generate the tree from the given parameters
         $tree = $this->getClassService()->toTree($clazz, $options);
 
-        $tree = $this->addPermissions($tree);
-
         function sortTree(&$tree)
         {
             usort($tree, function ($a, $b) {

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'Statistics and aggregated data',
     'description' => 'Extension for monitoring of the tao events. Fast access to statistics data',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '3.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis'        => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -148,6 +148,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('2.2.2');
         }
 
-        $this->skip('2.2.2', '3.1.0');
+        $this->skip('2.2.2', '3.1.1');
     }
 }


### PR DESCRIPTION
`\tao_actions_RdfController::addPermissions` was used to add permission icons on the resources tree. 
Not it is not needed anymore and deprecated.